### PR TITLE
Add z-index to global-alert.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -118,6 +118,7 @@ q, blockquote {
   background: rgba(255, 32, 32, .66);
   color: #fff;
   text-align: center;
+  z-index: 1;
 }
 
 .global-notify {


### PR DESCRIPTION
HI, I fixed an issue about stacking order of elements.

before:
<img width="888" alt="screenshot" src="https://cloud.githubusercontent.com/assets/6201376/15235991/416aa328-18fb-11e6-9343-3b019915e5c2.png">

after:
<img width="882" alt="2016-05-13 11 24 38" src="https://cloud.githubusercontent.com/assets/6201376/15236195/5b2bd4b0-18fd-11e6-8630-a82760ef9556.png">
