### PR TITLE
Fix to save tags_text to revisions

### DIFF
--- a/app/builders/article_builder.rb
+++ b/app/builders/article_builder.rb
@@ -16,6 +16,7 @@ class ArticleBuilder
     @revision.title = params.delete(:title)
     @revision.body = params.delete(:body)
     @revision.note = params.delete(:note).to_s
+    @revision.tags_text = params.delete(:tags_text).to_s
     @revision.published_at = Time.zone.now
     @revision.revision_type =
       case params[:publish_type]
@@ -41,9 +42,8 @@ class ArticleBuilder
       @article.published_at ||= Time.zone.now if @revision.published?
       @article.save!
 
-      @article.tags_text = params.delete(:tags_text).to_s
+      @article.tags_text = @revision.tags_text
       @revision.article_id = @article.id
-      @revision.tags_text = params.delete(:tags_text).to_s
       @revision.save!
     end
 

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -1,0 +1,56 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id                 :string(128)      not null, primary key
+#  user_id            :integer
+#  title              :string(128)
+#  newest_revision_id :integer
+#  view_count         :integer          default(0), not null
+#  stock_count        :integer          default(0), not null
+#  comment_count      :integer          default(0), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  published_at       :datetime
+#  publish_type       :integer          default(0)
+#
+
+require 'rails_helper'
+
+RSpec.describe ArticlesController, type: :controller do
+  describe 'POST :create' do
+    subject { post :create, **params, format: 'json' }
+
+    before(:each) { allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user) }
+    let(:current_user) { create(:user) }
+    let(:revision_hash) { attributes_for(:revision, user: current_user) }
+    let(:params) do
+      {
+        title:        revision_hash[:title],
+        tags_text:    revision_hash[:tags_text],
+        body:         revision_hash[:body],
+        note:         revision_hash[:note],
+        publish_type: 'public_item',
+        name:         revision_hash[:user].name
+      }
+    end
+
+    it { is_expected.to be_success }
+    it do
+      subject
+      article = current_user.articles.last
+      revision = article.newest_revision
+      aggregate_failures 'testing article' do
+        expect(article.title).to        eq params[:title]
+        expect(article.publish_type).to eq params[:publish_type]
+      end
+      aggregate_failures 'testing revision' do
+        expect(revision.body).to          eq params[:body]
+        expect(revision.title).to         eq params[:title]
+        expect(revision.tags_text).to     eq params[:tags_text]
+        expect(revision.revision_type).to eq 'published'
+        expect(revision.note).to          eq params[:note]
+      end
+    end
+  end
+end

--- a/spec/factories/revisions.rb
+++ b/spec/factories/revisions.rb
@@ -21,7 +21,7 @@ FactoryGirl.define do
     title { Faker.name }
     body { Faker::Lorem.paragraph }
     note { Faker::Lorem.sentence }
-    tags_text { Faker::Lorem.words }
+    tags_text { Faker::Lorem.words.join(' ') }
     revision_type 2
   end
 end


### PR DESCRIPTION
Saving tags_text fails because call `params.delete(:tags_text)` twice.

before: blank text
after:  correct tags_text