### PR TITLE
TakeoverBuilder should not migrate other user's data

### DIFF
--- a/app/builders/takeover_builder.rb
+++ b/app/builders/takeover_builder.rb
@@ -11,7 +11,7 @@ class TakeoverBuilder
     ActiveRecord::Base.transaction do
       # takeover
       [Article, AttachmentFile, Comment, Revision].each do |klass|
-        klass.update_all(user_id: @user.id)
+        klass.where(user_id: from_user.id).update_all(user_id: @user.id)
       end
 
       # delete

--- a/spec/builders/takeover_builder_spec.rb
+++ b/spec/builders/takeover_builder_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe TakeoverBuilder, type: :model do
+  describe '#build' do
+    subject { TakeoverBuilder.new(@to_user).build(@from_user) }
+    before do
+      @from_user = create(:user)
+      @to_user   = create(:user)
+    end
+
+    describe 'migrate articles' do
+      before do
+        @other_user = create(:user)
+        @article1   = create(:article, user: @from_user)
+        @article2   = create(:article, user: @other_user)
+      end
+
+      it "to_user has from_user's articles" do
+        subject
+        expect(@to_user.article_ids).to eq [@article1.id]
+      end
+
+      it "other_user's articles have not been migrated" do
+        subject
+        expect(@other_user.articles).to eq [@article2]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixed a bug that all user's data would changed to current_user's one.