### PR TITLE
Fix deprecation warning for `delete_all`

### DIFF
--- a/app/builders/takeover_builder.rb
+++ b/app/builders/takeover_builder.rb
@@ -16,7 +16,7 @@ class TakeoverBuilder
 
       # delete
       [AccessToken, Authentication, Like, Stock].each do |klass|
-        klass.delete_all(user_id: from_user.id)
+        klass.where(user_id: from_user.id).delete_all
       end
 
       from_user.destroy!

--- a/spec/builders/takeover_builder_spec.rb
+++ b/spec/builders/takeover_builder_spec.rb
@@ -26,5 +26,18 @@ RSpec.describe TakeoverBuilder, type: :model do
         expect(@other_user.articles).to eq [@article2]
       end
     end
+
+    describe "delete from_user's stocks" do
+      before do
+        other_user = create(:user)
+        article    = create(:article, user: other_user)
+        @stock     = create(:stock, user: @from_user, article: article)
+      end
+
+      it "from_user's stocks are destroyed" do
+        subject
+        expect { @stock.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 end

--- a/spec/factories/stocks.rb
+++ b/spec/factories/stocks.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: stocks
+#
+#  id         :integer          not null, primary key
+#  article_id :string(128)      not null
+#  user_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+FactoryGirl.define do
+  factory :stock
+end


### PR DESCRIPTION
> DEPRECATION WARNING: Passing conditions to delete_all is deprecated and will be removed in Rails 5.1.
> To achieve the same use where(conditions).delete_all.
> (called from block (2 levels) in build at /home/travis/build/rutan/potmum/app/builders/takeover_builder.rb:19)