### PR TITLE
Keep user input when edit tag (with validation error occurs)

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -28,15 +28,16 @@ class TagsController < ApplicationController
   # GET /tags/:content/edit
   # タグ情報編集
   def edit
+    @tag_for_input = Tag.find(@tag.id)
   end
 
   # PUT /tags/:content
   # タグ情報更新
   def update
-    if @tag.update(tag_params)
-      redirect_to tag_path(@tag)
+    @tag_for_input = Tag.find(@tag.id)
+    if @tag_for_input.update(tag_params)
+      redirect_to tag_path(@tag_for_input)
     else
-      @tag.reload
       render :edit
     end
   end

--- a/app/views/tags/edit.html.slim
+++ b/app/views/tags/edit.html.slim
@@ -11,22 +11,25 @@
   .uk-panel.uk-panel-box
     .uk-panel-title
       | タグ情報の設定
-    - if @tag.errors
-      - @tag.errors.full_messages.each do |message|
+    - if @tag_for_input.errors
+      - @tag_for_input.errors.full_messages.each do |message|
         p.uk-text-danger
           = message
-    = form_for(@tag, html: {class: 'uk-form uk-form-horizontal'}) do |f|
+    / When name becomes validation error, tag_path(@tag_for_input) has changed.
+    / so use before-changed url here.
+    = form_for(@tag_for_input, url: tag_path(@tag), html: {class: 'uk-form uk-form-horizontal'}) do |f|
       .uk-form-row
         label.uk-form-label
           | URL
         .uk-form-controls
           p.wrap
+            / display before-changed url too.
             = tag_url(@tag)
       .uk-form-row
         label.uk-form-label
           | タグ名
         .uk-form-controls
-          input.uk-width-1-1 type='text' name='tag[name]' value=@tag.name
+          input.uk-width-1-1 type='text' name='tag[name]' value=@tag_for_input.name
           .uk-text-muted.uk-margin-small-top
             | 画面に表示される際の文字列です。URLは変更されません。<br>
             | アルファベットの大文字小文字などの修正にご利用ください。<br>
@@ -36,10 +39,10 @@
         .uk-form-controls
           .uk-grid
             label.uk-width-1-2.uk-width-medium-1-3
-              input type='radio' name='tag[is_menu]' value=1 checked=@tag.menu?
+              input type='radio' name='tag[is_menu]' value=1 checked=@tag_for_input.menu?
               | &nbsp;表示する
             label.uk-width-1-2.uk-width-medium-1-3
-              input type='radio' name='tag[is_menu]' value=0 checked=!@tag.menu?
+              input type='radio' name='tag[is_menu]' value=0 checked=!@tag_for_input.menu?
               | &nbsp;表示しない
           .uk-text-muted.uk-margin-small-top
             | サイドバーメニューに固定するタグに設定できます。

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe TagsController, type: :controller do
+  let(:current_user) { create(:user) }
+  before { allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user) }
+
+  describe 'PATCH :update' do
+    subject do
+      patch :update, params: {
+        id: @tag.content,
+        tag: { name: name, is_menu: '0' }
+      }
+    end
+
+    before do
+      @tag = create(:tag)
+    end
+
+    context 'valid name' do
+      let(:name) { 'rails' }
+      it { is_expected.to redirect_to(tag_path(id: name)) }
+      it 'tag name has changed' do
+        subject
+        expect(Tag.find(@tag.id).name).to eq name
+      end
+    end
+
+    context 'invalid name' do
+      let(:name) { 'ruby on rails' } # include spaces
+      it { is_expected.to render_template(:edit) }
+      it 'tag name has not changed' do
+        subject
+        expect(Tag.find(@tag.id).name).not_to eq name
+      end
+    end
+  end
+end


### PR DESCRIPTION
It is more usable to keep input of the form when validation error occurs.

If keep `name`, it chenges the action URL of the form.
I guess this is the reason why input is now discarded.

Therefore, separate `@tag` and `@tag_for_input`.
`@tag` holds the tag before changed.
`@tag_for_input` accepts user input.