### PR TITLE
Ignore node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.env.*
 .rbenv-version
 .ruby-version
+.node-version
 /public/attachment_files
 /public/assets
 /public/asset_pack


### PR DESCRIPTION
Because nbenv uses `.node-version`.