### PR TITLE
Support plain markdown view

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -37,7 +37,8 @@ class ArticlesController < ApplicationController
     view_countup
 
     respond_to do |format|
-      format.html { render }
+      format.html
+      format.md
       format.json { render_json @article }
     end
   end

--- a/app/views/articles/show.md.erb
+++ b/app/views/articles/show.md.erb
@@ -1,0 +1,2 @@
+<%= @article_d.title %>
+<%= @article_d.body %>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,3 +3,4 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+Mime::Type.register 'text/x-markdown', :md


### PR DESCRIPTION
In Qiita, plain markdown can be seen if you add the extention `.md` of the post URL.

http://blog.qiita.com/post/77994282605/qiita-md