### PR TITLE
[Fix #33] Display article's status in list

### DIFF
--- a/app/views/articles/_list.html.slim
+++ b/app/views/articles/_list.html.slim
@@ -25,6 +25,15 @@
             li
               a href=tag_path(tag)
                 = tag.name
+        ul.article-status-box
+          li
+            i.fa.fa-heart-o
+            |&nbsp;
+            = article.like_count
+          li
+            i.fa.fa-comment-o
+            |&nbsp;
+            = article.comment_count
 
   = paginate articles
 

--- a/frontend/stylesheets/index.scss
+++ b/frontend/stylesheets/index.scss
@@ -680,6 +680,7 @@ q, blockquote {
     margin: 0;
     padding: 15px 0;
     border-top: 1px solid #ccc;
+    position: relative;
 
     &:first-child {
       border-top: 0;
@@ -745,6 +746,31 @@ q, blockquote {
           border-right-width: 8px;
           border-right-color: #eee;
         }
+      }
+    }
+    .article-status-box {
+      position: absolute;
+      bottom: 15px; // .article-list > li padding-bottom
+      right: 0;
+      li {
+        display: inline-block;
+        font-size: 12px;
+        line-height: 16px;
+        height: 16px;
+        &:before {
+          display: inline-block;
+          content: '\002022';
+          color: rgba(0, 0, 0, .2);
+          margin: 0 5px;
+        }
+        &:first-child:before {
+          display: none;
+        }
+      }
+    }
+    &:last-child {
+      .article-status-box {
+        bottom: 0;
       }
     }
   }


### PR DESCRIPTION
Like counts and comment counts are indicator for viewing articles, so I want to display them in list.
(Stock count should not be displayed because it is not displayed in `articles#show`.