### PR TITLE
Fix too large link area

### DIFF
--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -119,10 +119,11 @@
             .article-author.uk-margin-bottom
               a href=user_path(name: @article.user)
                 img.avatar-image src=@article_d.user.avatar_url
-                .article-author-name
+              .article-author-name
+                a href=user_path(name: @article.user)
                   = @article_d.user.name
-                .article-author-text
-                  | #{@article_d.user.like_count} Contributes
+              .article-author-text
+                | #{@article_d.user.like_count} Contributes
             .article-author-link.uk-margin-top
               h4 人気の投稿
               ul.uk-list.uk-list-line


### PR DESCRIPTION
Only avatar and name should be `a` elements.

before:

![image](https://user-images.githubusercontent.com/203046/32500888-00418aa8-c41a-11e7-938b-9bff6d0e65ca.png)

after:

![image](https://user-images.githubusercontent.com/203046/32501138-8d66ded8-c41a-11e7-9233-ce0a08c70bda.png)
